### PR TITLE
新しいemscriptenで明示的に指定しないとエクスポートされなくなっていたユーティリティ関数をエクスポート

### DIFF
--- a/build/src/gcc-mach.mak
+++ b/build/src/gcc-mach.mak
@@ -43,7 +43,7 @@ CFLAGS_darwin =
 LDFLAGS_cygwin = -Wl,--enable-auto-import -Wl,--enable-stdcall-fixup
 LDFLAGS_mingw = -Wl,--enable-auto-import -Wl,--enable-stdcall-fixup -static
 EXPORTED_FUNCTIONS = "['_load','_unload','_request','_so_library_init','_so_library_cleanup','_so_getmoduleversion','_so_create','_so_dispose','_so_request','_so_free']"
-LDFLAGS_js = -Wl,--enable-auto-import -Wl,--enable-stdcall-fixup -O3 --memory-init-file 0 --pre-js em-pre.js --post-js em-post.js -s EXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS) -s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_js = -Wl,--enable-auto-import -Wl,--enable-stdcall-fixup -O3 --memory-init-file 0 --pre-js em-pre.js --post-js em-post.js -s EXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS) -s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall','cwrap','intArrayFromString','intArrayToString']" -s ALLOW_MEMORY_GROWTH=1
 LDFLAGS_linux = 
 LDFLAGS_freebsd = 
 LDFLAGS_darwin = 


### PR DESCRIPTION
nativeshioriがこれを前提にして組まれていたりする。